### PR TITLE
Add documentation for `IPINFO_CREDENTIALS` and `IP_HASH_SALT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,14 @@ In the summer of 2024, this process took less than 5 hours to bin all 170 GB of 
 
 #### Required Environment Variables
 
-The `map_binned_s3_logs_to_dandisets` command requires two environment variables to be:
-1. IPINFO_CREDENTIALS: An access token for the ipinfo.io service
-2. IP_HASH_SALT: A salt value for hashing IP addresses
+The `map_binned_s3_logs_to_dandisets` command requires two environment variables to be set:
+
+1. **IPINFO_CREDENTIALS**: An access token for the ipinfo.io service
+  - We use this service to extract general geographic region information (not exact physical addresses) for anonymized geographic statistics
+  - We extract country/region information (e.g. "US/California"), while also specially categorizing requests from known services (GitHub, AWS, GCP, VPN).
+2. **IP_HASH_SALT**: A salt value for hashing IP addresses
+  - We use hashing to anonymize IP addresses in the logs while still allowing for unique identification
+- The hashed values are used as keys in our caching system to track regions without storing actual IP addresses
 
 To set `IPINFO_CREDENTIALS`:
 1. Register at [ipinfo.io](https://ipinfo.io/) to get an API access token

--- a/README.md
+++ b/README.md
@@ -132,6 +132,38 @@ In the summer of 2024, this process took less than 5 hours to bin all 170 GB of 
 
 ### Mapping
 
+#### Required Environment Variables
+
+The `map_binned_s3_logs_to_dandisets` command requires two environment variables to be:
+1. IPINFO_CREDENTIALS: An access token for the ipinfo.io service
+2. IP_HASH_SALT: A salt value for hashing IP addresses
+
+To set `IPINFO_CREDENTIALS`:
+1. Register at [ipinfo.io](https://ipinfo.io/) to get an API access token
+2. After registration, obtain your access token from your account dashboard
+3. Set the `IPINFO_CREDENTIALS` environment variable to this value
+
+```bash
+export IPINFO_CREDENTIALS="your_token_here"
+```
+
+To set `IP_HASH_SALT`:
+1. Use the built-in `get_hash_salt` function (requires access to the original raw log files)
+
+```python
+from dandi_s3_log_parser.testing._helpers import get_hash_salt
+
+# Path to the folder containing the raw log files
+raw_logs_path = "/path/to/raw/logs"
+salt = get_hash_salt(base_raw_s3_log_folder_path=raw_logs_path)
+print(f"Generated IP_HASH_SALT: {salt}")
+```
+2. Set the `IP_HASH_SALT` environment variable to this generated value
+
+```bash
+export IP_HASH_SALT="hash_salt_here"
+```
+
 To map:
 
 ```bash


### PR DESCRIPTION
Adds documentation for `IPINFO_CREDENTIALS` and `IP_HASH_SALT` environment variables required by the `map_binned_s3_logs_to_dandisets` function.

**IPINFO_CREDENTIALS**

This is an access token for the [ipinfo.io](https://ipinfo.io/) service, which is used to get geographical information about IP addresses.

 **IP_HASH_SALT**
This is a salt value used for hashing IP addresses to maintain privacy while still allowing for geographical analysis.
